### PR TITLE
Adds no pinned-versions and include travis

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,7 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "pinVersions": false,
+  "travis": true
 }


### PR DESCRIPTION
# What has changed and why?

Renovate can manage upgrading our dependencies once we stop work. We're still trialling this bot.
This config should tell renovate what we don't want our versions pinned.