### PR TITLE
improved service detail listings, 

### DIFF
--- a/src/components/Service/ServiceDetail.js
+++ b/src/components/Service/ServiceDetail.js
@@ -22,15 +22,15 @@ class ServiceDetail extends Component {
     this.displayServiceDetails = this.displayServiceDetails.bind(this);
   }
 
-  filters(category){
-    return category ? `&filters={"LEVEL_1_CATEGORY":"${category}"}` : '';
+  filters(serviceId){
+    return serviceId ? `&filters={"FSD_ID":"${serviceId}"}` : '';
   }
 
   loadServiceDetails(serviceId){
     if(!this.state.recordsLoaded){
       this.setState({loading: true, category: this.props.searchVars.category});
-      const FIELDS = 'LEVEL_1_CATEGORY,SERVICE_NAME,SERVICE_TARGET_AUDIENCES,SERVICE_DETAIL,DELIVERY_METHODS,COST_TYPE,COST_DESCRIPTION,SERVICE_REFERRALS';
-      let urldetails = encodeURI(`${process.env.REACT_APP_API_PATH}datastore_search?resource_id=${process.env.REACT_APP_API_RESOURCE_ID}&fields=${FIELDS}&q=${serviceId}&distinct=true`);
+      const FIELDS = '_id,LEVEL_1_CATEGORY,SERVICE_NAME,SERVICE_TARGET_AUDIENCES,SERVICE_DETAIL,DELIVERY_METHODS,COST_TYPE,COST_DESCRIPTION,SERVICE_REFERRALS';
+      let urldetails = encodeURI(`${process.env.REACT_APP_API_PATH}datastore_search?resource_id=${process.env.REACT_APP_API_RESOURCE_ID}&fields=${FIELDS}${this.filters(serviceId)}`);
       return axios.get(urldetails).then((response)=>{
         if (this.refs.myRef) this.setState({records: response.data.result.records, recordsLoaded: true});
         this.displayServiceDetails(this.props.searchVars.category);
@@ -46,10 +46,8 @@ class ServiceDetail extends Component {
         if(!uniquecategories.includes(item.LEVEL_1_CATEGORY)){
           uniquecategories.push(item.LEVEL_1_CATEGORY);
         }
-        if (!unique[item.SERVICE_NAME]) {
-          if(item.LEVEL_1_CATEGORY === currentCategory)  uniqueServices.push(item);
-          unique[item.SERVICE_NAME] = item;
-        }
+        if(item.LEVEL_1_CATEGORY === currentCategory)  uniqueServices.push(item);
+        unique[item.SERVICE_NAME] = item;
       });
       const clone = {...this.props.searchVars};
       clone.category = currentCategory;


### PR DESCRIPTION
Using the querystring filter instead of the q parameter to more accurately fetch the service details
This also now lists the service details per category, noting that the same service listings appear in different categories.

- [x] has automated tests
- [ ] at least one a reviewer ran the code
- [x] tested in small screen
- [x] i18n
- [x] tested in screen reader/contrast <-- remove this if no UX change
