### PR TITLE
distance away from address, proximity margins to assist iphone users

### DIFF
--- a/src/components/Service/Service.js
+++ b/src/components/Service/Service.js
@@ -11,7 +11,8 @@ class Service extends Component {
       <div>
         <div className="service">
           <div className="search-result-hero">
-            <Link to={`/service/${this.props.results.FSD_ID}${this.props.searchVars.category ? '/'+encodeURIComponent(this.props.searchVars.category) : ''}`}><h2>{this.props.results.PROVIDER_NAME}</h2></Link>
+            <h2><Link to={`/service/${this.props.results.FSD_ID}${this.props.searchVars.category ? '/'+encodeURIComponent(this.props.searchVars.category) : ''}`}>{this.props.results.PROVIDER_NAME}</Link></h2>
+            {this.props.results.DISTANCE && <small>{((this.props.results.DISTANCE*1)/1000).toFixed(1)} km</small>}
             <ServiceContactDetail phone={this.props.results.PUBLISHED_PHONE_1} email={this.props.results.PUBLISHED_CONTACT_EMAIL_1} hours={this.props.results.PROVIDER_CONTACT_AVAILABILITY} />
           </div>
           <ServiceDetail results={this.props.results} changeCategory={this.props.changeCategory} searchVars={this.props.searchVars} serviceId={this.props.serviceId} loadimmediately={false} loadResults={this.props.loadResults} />

--- a/src/styles/Proximity.css
+++ b/src/styles/Proximity.css
@@ -1,6 +1,8 @@
 .proximity {
   max-width: 450px;
-  margin-top: 1em; }
+  margin-top: 1em;
+  margin-left: 1em;
+  margin-right: 1em; }
 
 .range input {
   width: 93%;

--- a/src/styles/Service.css
+++ b/src/styles/Service.css
@@ -55,6 +55,7 @@ a {
     margin-bottom: 3px;
     margin-top: 0; }
   .search-result-hero ul {
-    margin-bottom: 0; }
+    margin-bottom: 0;
+    margin-top: 1em; }
 
 /*# sourceMappingURL=Service.css.map */

--- a/src/styles/Service.css
+++ b/src/styles/Service.css
@@ -50,7 +50,7 @@ a {
     color: #35a744; }
   .search-result-hero h2 {
     font-size: 24px;
-    margin: 7px 0; }
+    margin: 7px 0 0; }
   .search-result-hero p {
     margin-bottom: 3px;
     margin-top: 0; }

--- a/src/styles/scss/Proximity.scss
+++ b/src/styles/scss/Proximity.scss
@@ -3,6 +3,8 @@
 .proximity {
   max-width: 450px;
   margin-top: 1em;
+  margin-left: 1em;
+  margin-right: 1em;
 }
 
 .range input {

--- a/src/styles/scss/Service.scss
+++ b/src/styles/scss/Service.scss
@@ -70,6 +70,7 @@ a {
 
   ul {
     margin-bottom: 0;
+    margin-top: 1em;
   }
 }
 

--- a/src/styles/scss/Service.scss
+++ b/src/styles/scss/Service.scss
@@ -60,7 +60,7 @@ a {
 
   h2 {
     font-size: 24px;
-    margin: 7px 0;
+    margin: 7px 0 0;
   }
 
   p {


### PR DESCRIPTION
Add small distance (in km) under listing title if distance has been calculated
Also adds margin to sides of range slider to assist iphone users

# How to test this change

- [x] has automated tests
- [ ] at least one a reviewer ran the code
- [x] tested in small screen
- [x] i18n
- [x] tested in screen reader/contrast <-- remove this if no UX change
